### PR TITLE
Fix warning in account selector.

### DIFF
--- a/src/AccountSelector.jsx
+++ b/src/AccountSelector.jsx
@@ -22,7 +22,7 @@ export default function NodeInfo(props) {
   useEffect(() => {
     setAccountSelected(initialAddress);
     setAccountAddress(initialAddress);
-  }, [])
+  }, [setAccountAddress, initialAddress])
 
   return (
     <Menu


### PR DESCRIPTION
I recently pushed https://github.com/substrate-developer-hub/substrate-ui-template/commit/74827ca00b1a6051e449efbd669e299a2a164110 directly to master instead of a topic branch by accident.

This PR solves the warning `Line 25: React Hook useEffect has missing dependencies: 'initialAddress' and 'setAccountAddress'. Either include them or remove the dependency array react-hooks/exhaustive-deps` which that commit introduces.

