### PR TITLE
WIP: Relates to #46. Extrinsics should check for both args and sudo

### DIFF
--- a/src/substrate-lib/components/TxButton.js
+++ b/src/substrate-lib/components/TxButton.js
@@ -31,8 +31,29 @@ export default function TxButton({
     }
     setStatus("Sending...");
 
-    // Check if this transaction needs sudo
-    let txExecute = sudo ? tx.sudo(...params) : tx(...params);
+    // Check if this transaction has any arguments
+    let args = params.length && params[0].length ? params : undefined;
+    let txExecute;
+
+    // If this transaction "has no" args, check if we have sudo 
+    switch(!args) {
+      case !sudo:
+        txExecute = tx();
+        break;
+      case sudo:
+        txExecute = tx.sudo();
+        break;
+    }
+
+    // If this transaction "has" args, check if we have sudo
+    switch(args) {
+      case !sudo:
+        txExecute = tx(args);
+        break;
+      case sudo:
+        txExecute = tx.sudo(args);
+        break;
+    }
 
     txExecute.signAndSend(fromParam, ({ status }) => {
       status.isFinalized ?


### PR DESCRIPTION
This does not work if the user is using a custom runtime that does not include the Sudo Module (perhaps they don't want the Sudo Module for some reason), because it will return `tx.sudo` is not a function.
We need to address this issue first before going further with this PR https://github.com/substrate-developer-hub/substrate-front-end-template/issues/35
I also forgot to include the default case in the switch statement...