### PR TITLE
Remove `api.query.templateModule.something` check

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,8 +69,7 @@ export default function App () {
             <Events />
           </Grid.Row>
           <Grid.Row>
-            {api.query.templateModule &&
-            api.query.templateModule.something && (
+            {api.query.templateModule && (
               <TemplateModule accountPair={accountPair} />
             )}
           </Grid.Row>


### PR DESCRIPTION
To allow the `templateModule` file to be easily used in other tutorials like PoE, we need to reduce the check that is happening here.