### PR TITLE
Allows using rpc to specify remote websocket connection (fix #80)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@polkadot/util-crypto": "^2.2.1",
     "big.js": "^5.2.2",
     "prop-types": "^15.7.2",
+    "query-string": "^6.11.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "3.2.0",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -8,6 +8,7 @@ const envVarNames = [
   'REACT_APP_DEVELOPMENT_KEYRING'
 ];
 const envVars = envVarNames.reduce((mem, n) => {
+  // Remove the `REACT_APP_` prefix
   if (process.env[n] !== undefined) mem[n.slice(10)] = process.env[n];
   return mem;
 }, {});

--- a/src/substrate-lib/SubstrateContext.js
+++ b/src/substrate-lib/SubstrateContext.js
@@ -1,9 +1,14 @@
 import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
+import queryString from 'query-string';
 import config from '../config';
 
+const parsedQuery = queryString.parse(window.location.search);
+const connectedSocket = parsedQuery.rpc || config.PROVIDER_SOCKET;
+console.log(`Connected socket: ${connectedSocket}`);
+
 const INIT_STATE = {
-  socket: config.PROVIDER_SOCKET,
+  socket: connectedSocket,
   types: config.CUSTOM_TYPES,
   keyring: null,
   keyringState: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8890,6 +8890,15 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.11.0.tgz#dc27a05733d1be66f16d0f83dfa957270f45f66d"
+  integrity sha512-jS+me8X3OEGFTsF6kF+vUUMFG/d3WUCvD7bHhfZP5784nOq1pjj8yau/u86nfOncmcN6ZkSWKWkKAvv/MGxzLA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -9993,6 +10002,11 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -10096,6 +10110,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Allow setting remote rpc via URL query string. 

E.g: https://substrate.dev/substrate-front-end-template/?rpc=ws://127.0.0.1:9944

The above URL will connect to your locally running node after this PR is merged to master and the static site deployed in github page.

Fix: #80