### PR TITLE
Display the connected node addr & "fork me on gihub" banner

### DIFF
--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -1,0 +1,3 @@
+.github-fork-ribbon.right-bottom:before {
+  background-color: #222
+}

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
+    <!-- github ribbon style: https://github.com/simonwhitaker/github-fork-ribbon-css -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
+    <link rel="stylesheet" href="%PUBLIC_URL%/assets/main.css" />
     <title>Substrate Front End Template</title>
   </head>
   <body>
@@ -34,5 +38,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <a class="github-fork-ribbon right-bottom fixed" target='_blank' href="https://github.com/substrate-developer-hub/substrate-front-end-template" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
   </body>
 </html>

--- a/src/NodeInfo.js
+++ b/src/NodeInfo.js
@@ -4,7 +4,7 @@ import { Card, Icon, Grid } from 'semantic-ui-react';
 import { useSubstrate } from './substrate-lib';
 
 function Main (props) {
-  const { api } = useSubstrate();
+  const { api, socket } = useSubstrate();
   const [nodeInfo, setNodeInfo] = useState({});
 
   useEffect(() => {
@@ -31,12 +31,7 @@ function Main (props) {
           <Card.Meta>
             <span>{nodeInfo.chain}</span>
           </Card.Meta>
-          <Card.Description>
-            Built using the{' '}
-            <a href='https://github.com/substrate-developer-hub/substrate-front-end-template'>
-              Substrate Front End Template
-            </a>
-          </Card.Description>
+          <Card.Description>{socket}</Card.Description>
         </Card.Content>
         <Card.Content extra>
           <Icon name='setting' />v{nodeInfo.nodeVersion}


### PR DESCRIPTION
close #152 

Trying to follow the new rule that we PR the latest development to `development` branch and keep `master` to be the stable release branch.

How it looks now:

![Screenshot 2021-04-16 at 18 41 25](https://user-images.githubusercontent.com/898091/115013333-77d2ca80-9ee3-11eb-8143-d87fdb80f046.png)