### PR TITLE
Fixing CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
             mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
             git config --global user.email "devhub-deploy@users.noreply.github.com"
             git config --global user.name "Devhub Deployer"
+            yarn build
             yarn deploy
 
 workflows:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint": "eslint src/**/*.js",
     "lint:ci": "eslint src/**/*.js --max-warnings=0",
     "lint:fix": "eslint --fix src/**/*.js",
-    "predeploy": "yarn build",
     "deploy": "gh-pages -d build -m '[ci skip] Updates'"
   },
   "dependencies": {


### PR DESCRIPTION
`yarn predeploy` is no longer called before `yarn deploy` in yarn 2. So we need to manually invoke it in the CI script.