### PR TITLE
`substrateKitties` pallet name fix

### DIFF
--- a/src/Kitties.js
+++ b/src/Kitties.js
@@ -29,9 +29,9 @@ export default function Kitties (props) {
     let unsub = null;
 
     const asyncFetch = async () => {
-      unsub = await api.query.kitties.kittyCnt(async cnt => {
+      unsub = await api.query.substrateKitties.kittyCnt(async cnt => {
         // Fetch all kitty keys
-        const entries = await api.query.kitties.kitties.entries();
+        const entries = await api.query.substrateKitties.kitties.entries();
         const hashes = entries.map(convertToKittyHash);
         setKittyHashes(hashes);
       });
@@ -48,7 +48,7 @@ export default function Kitties (props) {
     let unsub = null;
 
     const asyncFetch = async () => {
-      unsub = await api.query.kitties.kitties.multi(kittyHashes, kitties => {
+      unsub = await api.query.substrateKitties.kitties.multi(kittyHashes, kitties => {
         const kittyArr = kitties
           .map((kitty, ind) => constructKitty(kittyHashes[ind], kitty.value));
         setKitties(kittyArr);
@@ -67,14 +67,14 @@ export default function Kitties (props) {
   useEffect(subscribeKittyCnt, [api, keyring]);
 
   return <Grid.Column width={16}>
-    <h1>Kitties</h1>
-    <KittyCards kitties={kitties} accountPair={accountPair} setStatus={setStatus}/>
-    <Form style={{ margin: '1em 0' }}>
+  <h1>Kitties</h1>
+  <KittyCards kitties={kitties} accountPair={accountPair} setStatus={setStatus}/>
+  <Form style={{ margin: '1em 0' }}>
       <Form.Field style={{ textAlign: 'center' }}>
         <TxButton
           accountPair={accountPair} label='Create Kitty' type='SIGNED-TX' setStatus={setStatus}
           attrs={{
-            palletRpc: 'kitties',
+            palletRpc: 'substrateKitties',
             callable: 'createKitty',
             inputParams: [],
             paramFields: []

--- a/src/KittyCards.js
+++ b/src/KittyCards.js
@@ -33,7 +33,7 @@ const TransferModal = props => {
         accountPair={accountPair} label='Transfer' type='SIGNED-TX' setStatus={setStatus}
         onClick={confirmAndClose}
         attrs={{
-          palletRpc: 'kitties',
+          palletRpc: 'substrateKitties',
           callable: 'transfer',
           inputParams: [formValue.target, kitty.id],
           paramFields: [true, true]
@@ -72,7 +72,7 @@ const SetPrice = props => {
         accountPair={accountPair} label='Transfer' type='SIGNED-TX' setStatus={setStatus}
         onClick={confirmAndClose}
         attrs={{
-          palletRpc: 'kitties',
+          palletRpc: 'substrateKitties',
           callable: 'setPrice',
           inputParams: [formValue.target, kitty.price],
           paramFields: [true, true]


### PR DESCRIPTION
In order to make Kitties Tutorial Parts 1-2 be consistent to each other, we need to use the same `substrateKitties` pallet name across their codebase.

(see [ Fixies to Kitties Part2, to be compatible with Part1 #357 ](https://github.com/substrate-developer-hub/substrate-docs/pull/357))