### PR TITLE
Update TemplateModule.js react hook

### DIFF
--- a/src/TemplateModule.js
+++ b/src/TemplateModule.js
@@ -46,7 +46,7 @@ function Main(props) {
     // This is a subscription, so it will always get the latest value,
     // even if it changes.
     api.query.templateModule
-      .proofs(digest, result => {
+      .claims(digest, result => {
         // Our storage item returns a tuple, which is represented as an array.
         if (result.inspect().inner) {
           const [owner, block] = result.toHuman()


### PR DESCRIPTION
Solution to https://github.com/substrate-developer-hub/substrate-front-end-template/issues/251#issue-1327954048   "api.query.templateModule.proofs is not a function" error in the browser.  The tutorial no longer uses the front-end-template.  Close if you like but I did find the custom front end a good learning experience. 