### PR TITLE
fix: balances.transfer is not available

### DIFF
--- a/src/Transfer.js
+++ b/src/Transfer.js
@@ -81,7 +81,7 @@ export default function Main(props) {
             setStatus={setStatus}
             attrs={{
               palletRpc: 'balances',
-              callable: 'transfer',
+              callable: 'transferAllowDeath',
               inputParams: [addressTo, amount],
               paramFields: [true, true],
             }}


### PR DESCRIPTION
# Overview

This PR is to fix a bug preventing users do transfer by clicking the Submit button. Simply use `balances.transfrAllowDeath` insteadof `balances.transfer`

# Bug

An error is aroused after clicking the Submit button when I want to make a transfer.

![image](https://github.com/substrate-developer-hub/substrate-front-end-template/assets/57085147/8ed63f7c-2d1d-49ea-97ba-e1828b598144)

![image](https://github.com/substrate-developer-hub/substrate-front-end-template/assets/57085147/57dbe339-346c-431b-b2d6-9e03800f766a)

# Cause

It is because the `balances.transfer` is not available any more according to the [Polkadot.js](https://polkadot.js.org/docs/substrate/extrinsics/#balances) document.

![image](https://github.com/substrate-developer-hub/substrate-front-end-template/assets/57085147/43bfca8b-dd03-4da3-9870-10c6a2db4266)
